### PR TITLE
Changes to bundler command to suit 1.0

### DIFF
--- a/lib/hooks/post-reset.rb
+++ b/lib/hooks/post-reset.rb
@@ -68,7 +68,7 @@ end
 
 if changed_files.include?('Gemfile') || changed_files.include?('Gemfile.lock')
   # update bundled gems if manifest file has changed
-  system %(umask 002 && bundle install)
+  system %(umask 002 && bundle install --deployment)
 end
 
 # run migrations when new ones added


### PR DESCRIPTION
Bundler 1.0 expects Gemfile.lock to be committed, so check for changes in that file too (eg updated dependencies picked up by running "bundler update".

Also changed it to run "bundler install --deployment", as recommended for production.
