### PR TITLE
On clean server builds, the deploy scripts fail because bundler is not installed

### DIFF
--- a/lib/git_deploy.rb
+++ b/lib/git_deploy.rb
@@ -38,6 +38,7 @@ class GitDeploy < Thor
       cmd << "sed -i'' -e 's/master/#{branch}/' .git/HEAD" unless branch == 'master'
       cmd << "git config --bool receive.denyNonFastForwards false" if options.shared?
       cmd << "git config receive.denyCurrentBranch ignore"
+      cmd << "gem install bundler --no-rdoc --no-ri"
     end
 
     invoke :hooks


### PR DESCRIPTION
The setup should ensure that bundler is installed otherwise the deploy scripts will fail.

Alternatively there could be documentation which should say that bundler is a prerequisite.
