### PR TITLE
fix setup cmd when sudo is disabled

### DIFF
--- a/lib/git_deploy.rb
+++ b/lib/git_deploy.rb
@@ -28,6 +28,7 @@ class GitDeploy < Thor
     unless run_test("test -x #{deploy_to}")
       run ["#{sudo}mkdir -p #{deploy_to}"] do |cmd|
         cmd << "#{sudo}chown $USER #{deploy_to}" if options.sudo?
+        cmd
       end
     end
 


### PR DESCRIPTION
When run setup task, if sudo is disabled, cmd is empty because block return nil. Setup task result to following error :

```
lib/git_deploy/ssh_methods.rb:17:in `run': undefined method `gsub' for nil:NilClass (NoMethodError)
```

this patch fix this.
