### PR TITLE
Set bash in Interactive mode and exit on errors in post-receive hook.

### DIFF
--- a/lib/hooks/post-receive.sh
+++ b/lib/hooks/post-receive.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/bash -i
+set -e
+
 if [ "$GIT_DIR" = "." ]; then
   # The script has been called as a hook; chdir to the working copy
   cd ..


### PR DESCRIPTION
In interactive mode users' /etc/bash.bashrc (or /etc/bashrc, depending on OS) and ~/.bashrc will be sourced, allowing rbenv and RVM installations to be used without continual re-editing of deploy scripts. 'set -e' merely stops execution on failure of a sub-command. No runtime penalty for either change is incurred.
