### PR TITLE
Update lib/git_deploy.rb

### DIFF
--- a/lib/git_deploy.rb
+++ b/lib/git_deploy.rb
@@ -21,7 +21,7 @@ class GitDeploy < Thor
 
   desc "setup", "Create the remote git repository and install push hooks for it"
   method_option :shared, :aliases => '-g', :type => :boolean, :default => true
-  method_option :sudo, :aliases => '-s', :type => :boolean, :default => true
+  method_option :sudo, :aliases => '-s', :type => :boolean, :default => false
   def setup
     sudo = options.sudo? ? "#{sudo_cmd} " : ''
 


### PR DESCRIPTION
sudo should be considered bad when doing deploys. It is also a bad practice when installing in /usr/local. If you dont have permission by the user used it shouldnt be done as default at least.
