### PR TITLE
Support nested submodules with the --recursive flag

### DIFF
--- a/lib/hooks/post-receive.sh
+++ b/lib/hooks/post-receive.sh
@@ -42,7 +42,7 @@ if [ -z "${oldrev//0}" ]; then
   chmod 0664 $logfile $restart
 
   # init submodules
-  git submodule update --init | tee -a $logfile
+  git submodule update --init --recursive | tee -a $logfile
 else
   # log timestamp
   echo ==== $(date) ==== >> $logfile


### PR DESCRIPTION
In the `post-receive.sh` hook, I'm using the `--recursive` flag to update any submodules that are nested. 
