### PR TITLE
Fixed bug in post-receive hook

### DIFF
--- a/lib/hooks/post-receive.sh
+++ b/lib/hooks/post-receive.sh
@@ -48,5 +48,5 @@ else
   echo ==== $(date) ==== >> $logfile
 
   # execute the deploy hook in background
-  [ -x deploy/after_push ] && nohup deploy/after_push $oldrev $newrev 1>>$logfile 2>>$logfile &
+  [ -x deploy/after_push ] && (nohup deploy/after_push $oldrev $newrev 1>>$logfile 2>>$logfile &)
 fi


### PR DESCRIPTION
Sometimes the post-receive hook won't exit if there is a child process runing.
