### PR TITLE
Strip whitespace from git remote

### DIFF
--- a/lib/git_deploy/configuration.rb
+++ b/lib/git_deploy/configuration.rb
@@ -49,6 +49,7 @@ class GitDeploy
           abort "Error: Remote url for #{remote.inspect} points to GitHub. Can't deploy there!"
         else
           url = 'ssh://' + url.sub(%r{:/?}, '/') unless url =~ %r{^[\w-]+://}
+          url.strip!
           begin
             url = URI.parse url
           rescue


### PR DESCRIPTION
On my local machine, the 'remote' string always ended up with a space at the end. I'm not sure this is the best fix, but adding this 'strip' fixed the issue for me. 

The issue occurred on my Mac (Mountain Lion), with system-default git (git version 1.7.12.4 (Apple Git-37)) and ruby (ruby 1.8.7 (2012-02-08 patchlevel 358) [universal-darwin12.0]

This patch fixes it for me. Happy to help debug or help if you need more repro info.
