### PR TITLE
skip remotes without url

### DIFF
--- a/lib/git_deploy/configuration.rb
+++ b/lib/git_deploy/configuration.rb
@@ -36,7 +36,9 @@ class GitDeploy
     def remote_urls(remote)
       git_config["remote -v"].to_s.split("\n").
         select {|l| l =~ /^#{remote}\t/ }.
-        map {|l| l.split("\t")[1].sub(/\s+\(.+?\)$/, '') }
+        map {|l| l.split("\t")[1] }.
+        reject {|l| l.nil? }.
+        map {|l| l.sub(/\s+\(.+?\)$/, '')}
     end
 
     def remote_url(remote = options[:remote])


### PR DESCRIPTION
If there is only a `pushurl` for a remote the `remote_urls` fails on `l.split("\t")[1].sub(/\s+\(.+?\)$/, '')` because the split results in only 1 part.

``` bash
$ git remote -v
sonny   deploy@x.x.x.x:/usr/share/php/fetch-cms-core/source (push)
sonny
staging deploy@x.x.x.x:/usr/share/php/fetch-cms-core/source (push)
staging
vito    deploy@x.x.x.x:/usr/share/php/fetch-cms-core/source (push)
vito
```
