### PR TITLE
Check for db/migrate directory before running rake db:migrate

### DIFF
--- a/lib/git_deploy/templates/before_restart.rb
+++ b/lib/git_deploy/templates/before_restart.rb
@@ -21,9 +21,11 @@ end
 if File.file? 'Rakefile'
   tasks = []
 
-  num_migrations = `git diff #{oldrev} #{newrev} --diff-filter=A --name-only -z db/migrate`.split("\0").size
-  # run migrations if new ones have been added
-  tasks << "db:migrate" if num_migrations > 0
+  if File.directory? 'db/migrate'
+    num_migrations = `git diff #{oldrev} #{newrev} --diff-filter=A --name-only -z db/migrate`.split("\0").size
+    # run migrations if new ones have been added
+    tasks << "db:migrate" if num_migrations > 0
+  end
 
   # precompile assets
   changed_assets = `git diff #{oldrev} #{newrev} --name-only -z app/assets`.split("\0")


### PR DESCRIPTION
When using Rails without a database, there is no db/migrate directory and running `rake db:migrate`
generates an error.

This patch adds a check in the `before_restart.rb` template to avoid this error.
