### PR TITLE
Automatically load RVM if available or needed

### DIFF
--- a/lib/hooks/post-receive.sh
+++ b/lib/hooks/post-receive.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+for group in `groups`; do
+  if [ "${group}" = "rvm" ] && [ -f "/etc/profile.d/rvm.sh" ]; then 
+    source /etc/profile.d/rvm.sh
+  fi
+done
+
 if [ "$GIT_DIR" = "." ]; then
   # The script has been called as a hook; chdir to the working copy
   cd ..


### PR DESCRIPTION
When deploying to remotes that use RVM, the /etc/profile.d/rvm.sh environment is not automatically loaded. In the past we have simply edited the post-receive hook by hand, but it seems it would be nice to automatically do so if the user is in the rvm group and the /etc/profile.d/rvm.sh script exists.