### PR TITLE
Update post-receive.sh

### DIFF
--- a/lib/hooks/post-receive.sh
+++ b/lib/hooks/post-receive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ "$GIT_DIR" = "." ]; then


### PR DESCRIPTION
Fix `.git/hooks/post-receive: /bin/bash: bad interpreter: No such file or directory` issues when the bash is installed at a different path (e.g. `/usr/local/bin/bash`) than just `/bin/bash`.
