### PR TITLE
handle ssh urls that use home relative paths (ie. paths starting with ~)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 bundler_args: "--without development"
 script: bundle exec rspec
 rvm:

--- a/lib/git_deploy/configuration.rb
+++ b/lib/git_deploy/configuration.rb
@@ -9,7 +9,16 @@ class GitDeploy
     extend Forwardable
     def_delegator :remote_url, :host
     def_delegator :remote_url, :port, :remote_port
-    def_delegator :remote_url, :path, :deploy_to
+
+    def deploy_to
+      @deploy_to ||= begin
+        if remote_url.path.start_with? '/~/'
+          remote_url.path[1..-1]
+        else
+          remote_url.path 
+        end
+      end
+    end
 
     def remote_user
       @user ||= begin

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -44,6 +44,15 @@ describe GitDeploy::Configuration do
       its(:deploy_to)   { should eq('/path/to/app') }
     end
 
+    context "scp-style with home" do
+      before { stub_remote_url 'git@example.com:~/path/to/app' }
+
+      its(:host)        { should eq('example.com') }
+      its(:remote_port) { should be_nil }
+      its(:remote_user) { should eq('git') }
+      its(:deploy_to)   { should eq('~/path/to/app') }
+    end
+
     context "pushurl only" do
       before {
         remote = options.fetch(:remote)


### PR DESCRIPTION
It's common for us to have scp style remote urls that use the '~' at the start of the path, to indicate the home directory of the user used at the start of the url. The conversion of these scp style urls to ssh:// urls breaks these paths and adds an initial '/' to the `deploy_to` path, causing git-deploy not to work.

There is no way (that I know of) to preserve these paths when converting to an ssh:// style uri, so we need to detect this situation and 'correct' the url by removing the initial '/'
