### PR TITLE
Don't display an error when no db/migrate

### DIFF
--- a/lib/git_deploy/templates/before_restart.rb
+++ b/lib/git_deploy/templates/before_restart.rb
@@ -21,7 +21,12 @@ end
 if File.file? 'Rakefile'
   tasks = []
 
-  num_migrations = `git diff #{oldrev} #{newrev} --diff-filter=A --name-only -z -- db/migrate`.split("\0").size
+  if File.exist?('db/migrate')
+    num_migrations = `git diff #{oldrev} #{newrev} --diff-filter=A --name-only -z -- db/migrate`.split("\0").size
+  else
+    num_migrations = 0
+  end
+
   # run migrations if new ones have been added
   tasks << "db:migrate" if num_migrations > 0
 


### PR DESCRIPTION
before_restart.rb would make git print an error message when run in a
Rails project without db/migrate. The error would be printed to stderr
which would result in num_migrations being set to 0 (which is correct).
However, printing the error message when there was no error is
confusing.

This commit introduces a check for the existence of db/migrate. If it
exists then git is called. Otherwise num_migrations is set to 0.
