### PR TITLE
Update net-ssh gem to resolve password protected ssh-key problem (Net::SSH::AuthenticationFailed)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,19 @@ PATH
   remote: .
   specs:
     git-deploy (0.6.1)
+      highline (~> 1.7)
       net-scp (~> 1.1)
-      net-ssh (~> 2.6)
+      net-ssh (~> 4.0)
       thor (= 0.14.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.4)
+    highline (1.7.8)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.1)
+    net-ssh (4.0.1)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -31,4 +33,4 @@ DEPENDENCIES
   rspec (~> 2.13.0)
 
 BUNDLED WITH
-   1.10.3
+   1.14.4

--- a/git-deploy.gemspec
+++ b/git-deploy.gemspec
@@ -5,8 +5,9 @@ Gem::Specification.new do |gem|
   gem.executables = %w[ git-deploy ]
 
   gem.add_dependency 'thor', '0.14.6'
-  gem.add_dependency 'net-ssh', '~> 2.6'
+  gem.add_dependency 'net-ssh', '~> 4.0'
   gem.add_dependency 'net-scp', '~> 1.1'
+  gem.add_dependency 'highline', '~> 1.7'
 
   gem.summary = "Simple git push-based application deployment"
   gem.description = "A tool to install useful git hooks on your remote repository to enable push-based, Heroku-like deployment on your host."


### PR DESCRIPTION
Using a `git-deploy` with a password protected ssh-key will cause it to raise following error:
```
/home/shahin/.gem/ruby/2.4.0/gems/net-ssh-2.6.8/lib/net/ssh/transport/session.rb:67:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
/home/shahin/.gem/ruby/2.4.0/gems/net-ssh-2.6.8/lib/net/ssh/transport/session.rb:78:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
/home/shahin/.gem/ruby/2.4.0/gems/net-ssh-2.6.8/lib/net/ssh/transport/cipher_factory.rb:98: warning: constant OpenSSL::Cipher::Cipher is deprecated
/home/shahin/.gem/ruby/2.4.0/gems/net-ssh-2.6.8/lib/net/ssh/transport/cipher_factory.rb:72: warning: constant OpenSSL::Cipher::Cipher is deprecated
/home/shahin/.gem/ruby/2.4.0/gems/net-ssh-2.6.8/lib/net/ssh.rb:207:in `start': shahin (Net::SSH::AuthenticationFailed)
        from /home/shahin/.gem/ruby/2.4.0/gems/git-deploy-0.6.1/lib/git_deploy/ssh_methods.rb:96:in `ssh_connection'
        from /home/shahin/.gem/ruby/2.4.0/gems/git-deploy-0.6.1/lib/git_deploy/ssh_methods.rb:43:in `ssh_exec'
        from /home/shahin/.gem/ruby/2.4.0/gems/git-deploy-0.6.1/lib/git_deploy/ssh_methods.rb:35:in `run_test'
        from /home/shahin/.gem/ruby/2.4.0/gems/git-deploy-0.6.1/lib/git_deploy.rb:28:in `setup'
        from /home/shahin/.gem/ruby/2.4.0/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
        from /home/shahin/.gem/ruby/2.4.0/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
        from /home/shahin/.gem/ruby/2.4.0/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
        from /home/shahin/.gem/ruby/2.4.0/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
        from /home/shahin/.gem/ruby/2.4.0/gems/git-deploy-0.6.1/bin/git-deploy:3:in `<top (required)>'
        from /home/shahin/.gem/ruby/2.3.0/bin/git-deploy:23:in `load'
        from /home/shahin/.gem/ruby/2.3.0/bin/git-deploy:23:in `<main>'
```
It turned out that the `net-ssh` library is responsible for this problem. So I updated it and since it needs `highline` gem to prevent echoing password while typing, I added this gem as well. All the tests are passing and `git-deploy` works with no problem again.