### PR TITLE
Gem update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 bundler_args: "--without development"
 script: bundle exec rspec
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
+  - '2.3'
+  - '2.4'
+  - '2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     git-deploy (0.6.1)
       net-scp (~> 1.1)
-      net-ssh (~> 2.6)
+      net-ssh (~> 5.0)
       thor (= 0.14.6)
 
 GEM
@@ -12,7 +12,7 @@ GEM
     diff-lcs (1.2.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.1)
+    net-ssh (5.2.0)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec (~> 2.13.0)
 
 BUNDLED WITH
-   1.10.3
+   2.0.1

--- a/git-deploy.gemspec
+++ b/git-deploy.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   gem.executables = %w[ git-deploy ]
 
   gem.add_dependency 'thor', '0.14.6'
-  gem.add_dependency 'net-ssh', '~> 2.6'
+  gem.add_dependency 'net-ssh', '~> 5.0'
   gem.add_dependency 'net-scp', '~> 1.1'
 
   gem.summary = "Simple git push-based application deployment"

--- a/git-deploy.gemspec
+++ b/git-deploy.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'thor', '0.14.6'
   gem.add_dependency 'net-ssh', '~> 5.0'
   gem.add_dependency 'net-scp', '~> 1.1'
+  gem.required_ruby_version = '>= 2.2.6'
 
   gem.summary = "Simple git push-based application deployment"
   gem.description = "A tool to install useful git hooks on your remote repository to enable push-based, Heroku-like deployment on your host."

--- a/lib/git_deploy/ssh_methods.rb
+++ b/lib/git_deploy/ssh_methods.rb
@@ -93,7 +93,7 @@ class GitDeploy
 
     def ssh_connection
       @ssh ||= begin
-        ssh = Net::SSH.start(host, remote_user, :port => remote_port)
+        ssh = Net::SSH.start(host, remote_user, :port => remote_port || 22)
         at_exit { ssh.close }
         ssh
       end


### PR DESCRIPTION
Update net-ssh dependency for higher version to get rid of this error
gems/net-ssh-2.6.8/lib/net/ssh/transport/kex/diffie_hellman_group1_sha1.rb:118:in `generate_key': undefined method `p=' for #<OpenSSL::PKey::DH:0x00007ff2e12cc348> (NoMethodError)

Use default port 22 if not specified in repo url.
Passing nil to net-ssh constructor is deprecated